### PR TITLE
Update Dockerfile-fpm-alpine

### DIFF
--- a/php-7.0/Dockerfile-fpm-alpine
+++ b/php-7.0/Dockerfile-fpm-alpine
@@ -18,13 +18,17 @@ RUN docker-php-ext-configure bcmath && \
         curl \
         iconv \
         exif \
-        intl \
         pdo_mysql \
         mbstring \
         mcrypt \
         zip \
         bcmath \
         soap
+        
+# fix for broken ext/intl install
+RUN apk add --update --no-cache libintl icu icu-dev && \
+    docker-php-ext-install intl && \
+    apk del icu-dev
 
 # Install PECL extensions
 # see http://stackoverflow.com/a/8154466/291573) for usage of `printf`


### PR DESCRIPTION
To be able to install intl ext with docker-php-ext-install additional libs are required.
Otherwise you get errors during build:
[..]
checking for icu-config... no
checking for location of ICU headers and libraries... not found
configure: error: Unable to detect ICU prefix or no failed. Please verify ICU install prefix and make sure icu-config works.
[..]

